### PR TITLE
fix CSRF setup in django settings

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -17,9 +17,12 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 DEBUG = os.getenv("DEBUG", "false") == "true"
 
 AZURE_WEBSITE_HOSTNAME = os.getenv("WEBSITE_HOSTNAME")
-
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"] + ([AZURE_WEBSITE_HOSTNAME] if AZURE_WEBSITE_HOSTNAME is not None else [])
+
 INTERNAL_IPS = ["127.0.0.1"]
+
+CSRF_TRUSTED_ORIGINS_ENV = os.getenv("CSRF_TRUSTED_ORIGINS")
+CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_ENV.split(",") if CSRF_TRUSTED_ORIGINS_ENV is not None else []
 
 INSTALLED_APPS = [
     "jazzmin",


### PR DESCRIPTION
### Changes

- add `CSRF_TRUSTED_ORIGINS` reading env in django settings